### PR TITLE
Filter not css files to prevent postcss errors (like css.map, etc..)

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,10 @@
                 return cb();
             }
 
+            if(!/.\.css$/.test(file.path)){
+                return cb();
+            }
+
             if (file.isStream()) {
                 this.emit('error', new gutil.PluginError('gulp-rtlcss', 'Streaming not supported'));
                 return cb();


### PR DESCRIPTION
Required when **gulp-sourcemaps**  configured to write to file ( not only css files in the stream)
E.g:

```
var gulp = require('gulp');
var autoprefixer = require('gulp-autoprefixer');
var rtlcss = require('gulp-rtlcss');
var rename = require('gulp-rename');
var  sourcemaps = require('gulp-sourcemaps');
gulp.task('styles', function () {
    return gulp.src(['/styles/*.css'])
        .pipe(sourcemaps.init())
        .pipe(autoprefixer(["last 2 versions", "> 1%"])) // Other post-processing.
        .pipe(sourcemaps.write('/'))
        .pipe(gulp.dest('dist')) // Output LTR stylesheets.
        .pipe(rtlcss()) // Convert to RTL.
        .pipe(rename({ suffix: '-rtl' })) // Append "-rtl" to the filename.
        .pipe(gulp.dest('dist')); // Output RTL stylesheets.
});
```
